### PR TITLE
feat(ios): Add Google Gemini model support with conditional UI

### DIFF
--- a/iOS/Pixie/Pixie/Data/ConfigurationManager.swift
+++ b/iOS/Pixie/Pixie/Data/ConfigurationManager.swift
@@ -44,6 +44,10 @@ class ConfigurationManager: ConfigurationManagerProtocol {
             notifyConfigurationChanged()
         }
     }
+    @UserDefaultsWrapper(key: "pixie.defaultModel", defaultValue: "gemini-2.5-flash")
+    var defaultModel: String {
+        didSet { notifyConfigurationChanged() }
+    }
     @UserDefaultsWrapper(key: "pixie.defaultQuality", defaultValue: "low")
     var defaultQuality: String {
         didSet { notifyConfigurationChanged() }
@@ -96,6 +100,7 @@ class ConfigurationManager: ConfigurationManagerProtocol {
     func reset() {
         baseURL = "https://openai-image-proxy.guitaripod.workers.dev"
         apiKey = nil
+        defaultModel = "gemini-2.5-flash"
         defaultQuality = "low"
         defaultSize = "auto"
         defaultOutputFormat = "webp"

--- a/iOS/Pixie/Pixie/Data/Models/EditingModels.swift
+++ b/iOS/Pixie/Pixie/Data/Models/EditingModels.swift
@@ -14,6 +14,7 @@ enum ToolbarMode {
 
 struct EditOptions {
     var prompt: String = ""
+    var model: String = "gemini-2.5-flash"
     var variations: Int = 1
     var size: ImageSize = .auto
     var quality: ImageQuality = .low

--- a/iOS/Pixie/Pixie/Data/Models/ImageModels.swift
+++ b/iOS/Pixie/Pixie/Data/Models/ImageModels.swift
@@ -123,12 +123,47 @@ struct ImageMetadataDetails: Codable, Hashable {
     let quality: String?
     let model: String?
     let revisedPrompt: String?
-    
+
     enum CodingKeys: String, CodingKey {
         case width, height, format
         case sizeBytes = "size_bytes"
         case creditsUsed = "credits_used"
         case quality, model
         case revisedPrompt = "revised_prompt"
+    }
+}
+
+enum ImageModel: String, CaseIterable {
+    case gemini = "gemini-2.5-flash"
+    case openai = "gpt-image-1"
+
+    var displayName: String {
+        switch self {
+        case .gemini: return "Gemini"
+        case .openai: return "OpenAI GPT"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .gemini: return "Fast & affordable (15 credits)"
+        case .openai: return "Advanced options (5-94 credits)"
+        }
+    }
+
+    var value: String { rawValue }
+
+    var fixedCost: Int? {
+        switch self {
+        case .gemini: return 15
+        case .openai: return nil
+        }
+    }
+
+    var requiresAdvancedOptions: Bool {
+        switch self {
+        case .gemini: return false
+        case .openai: return true
+        }
     }
 }

--- a/iOS/Pixie/Pixie/Models/ChatMessage.swift
+++ b/iOS/Pixie/Pixie/Models/ChatMessage.swift
@@ -10,6 +10,7 @@ struct ChatMessage: Hashable {
     let editingImage: UIImage?
     
     struct MessageMetadata {
+        let model: String?
         let size: String?
         let quality: String?
         let credits: Int?

--- a/iOS/Pixie/Pixie/Services/GenerationService.swift
+++ b/iOS/Pixie/Pixie/Services/GenerationService.swift
@@ -200,7 +200,7 @@ class GenerationService {
                     image: [imageDataUrl],
                     prompt: prompt,
                     mask: nil,
-                    model: "gpt-image-1",
+                    model: options.model,
                     n: options.variations,
                     size: options.size.value,
                     quality: options.quality.value,

--- a/iOS/Pixie/Pixie/Services/GenerationService.swift
+++ b/iOS/Pixie/Pixie/Services/GenerationService.swift
@@ -101,7 +101,7 @@ class GenerationService {
         
         let request = ImageGenerationRequest(
             prompt: prompt,
-            model: "gpt-image-1",
+            model: options.model,
             n: options.quantity,
             size: options.size,
             quality: options.quality,

--- a/iOS/Pixie/Pixie/ViewControllers/ChatGenerationViewController.swift
+++ b/iOS/Pixie/Pixie/ViewControllers/ChatGenerationViewController.swift
@@ -283,12 +283,23 @@ class ChatGenerationViewController: UIViewController {
         print("🖋️ ChatGenerationVC: Setting up generation options")
         viewModel.prompt = prompt
         currentOptions.prompt = prompt
-        currentOptions.size = inputBar.selectedSize.value
-        currentOptions.quality = inputBar.selectedQuality.value
-        currentOptions.outputFormat = inputBar.selectedFormat
-        currentOptions.compression = inputBar.selectedFormat != "png" ? inputBar.compressionLevel : nil
-        currentOptions.background = inputBar.selectedBackground
-        currentOptions.moderation = inputBar.selectedModeration
+        currentOptions.model = inputBar.selectedModel.value
+
+        if inputBar.selectedModel == .openai {
+            currentOptions.size = inputBar.selectedSize.value
+            currentOptions.quality = inputBar.selectedQuality.value
+            currentOptions.outputFormat = inputBar.selectedFormat
+            currentOptions.compression = inputBar.selectedFormat != "png" ? inputBar.compressionLevel : nil
+            currentOptions.background = inputBar.selectedBackground
+            currentOptions.moderation = inputBar.selectedModeration
+        } else {
+            currentOptions.size = "auto"
+            currentOptions.quality = "low"
+            currentOptions.outputFormat = nil
+            currentOptions.compression = nil
+            currentOptions.background = nil
+            currentOptions.moderation = nil
+        }
         print("🖋️ ChatGenerationVC: Calling viewModel.generateImages")
         viewModel.generateImages(with: currentOptions)
     }
@@ -665,6 +676,7 @@ extension ChatGenerationViewController: ChatTableViewDelegate {
 
 struct GenerationOptions {
     var prompt: String
+    var model: String
     var quantity: Int
     var size: String
     var sizeDisplay: String
@@ -684,6 +696,7 @@ struct GenerationOptions {
     static var `default`: GenerationOptions {
         GenerationOptions(
             prompt: "",
+            model: "gemini-2.5-flash",
             quantity: 1,
             size: "1024x1024",
             sizeDisplay: "Square",

--- a/iOS/Pixie/Pixie/ViewControllers/SettingsViewController.swift
+++ b/iOS/Pixie/Pixie/ViewControllers/SettingsViewController.swift
@@ -54,6 +54,7 @@ class SettingsViewController: UIViewController {
     }
     
     private enum DefaultsRow: Int, CaseIterable {
+        case model
         case quality
         case size
         case format
@@ -329,6 +330,28 @@ extension SettingsViewController: UITableViewDataSource {
         ])
         
         switch row {
+        case .model:
+            label.text = "AI Model"
+
+            let segmentedControl = UISegmentedControl(items: ["Gemini", "OpenAI GPT"])
+            segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+
+            switch configurationManager.defaultModel {
+            case "gemini-2.5-flash": segmentedControl.selectedSegmentIndex = 0
+            case "gpt-image-1": segmentedControl.selectedSegmentIndex = 1
+            default: segmentedControl.selectedSegmentIndex = 0
+            }
+
+            segmentedControl.addTarget(self, action: #selector(modelChanged(_:)), for: .valueChanged)
+            containerView.addSubview(segmentedControl)
+
+            NSLayoutConstraint.activate([
+                segmentedControl.topAnchor.constraint(equalTo: label.bottomAnchor, constant: 8),
+                segmentedControl.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+                segmentedControl.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+                segmentedControl.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+            ])
+
         case .quality:
             label.text = "Quality"
             
@@ -668,9 +691,9 @@ extension SettingsViewController: UITableViewDelegate {
     
     private func handleDefaultsSelection(at indexPath: IndexPath) {
         guard let row = DefaultsRow(rawValue: indexPath.row) else { return }
-        
+
         switch row {
-        case .quality, .size, .format, .background, .moderation:
+        case .model, .quality, .size, .format, .background, .moderation:
             break
         case .compression:
             if configurationManager.defaultOutputFormat != "png" {
@@ -735,7 +758,14 @@ extension SettingsViewController: UITableViewDelegate {
         updateAppearance()
         tableView.reloadData()
     }
-    
+
+    @objc private func modelChanged(_ sender: UISegmentedControl) {
+        haptics.impact(.click)
+        let models = ["gemini-2.5-flash", "gpt-image-1"]
+        configurationManager.defaultModel = models[sender.selectedSegmentIndex]
+        tableView.reloadData()
+    }
+
     @objc private func qualityChanged(_ sender: UISegmentedControl) {
         haptics.impact(.click)
         let qualities = ["low", "medium", "high", "auto"]

--- a/iOS/Pixie/Pixie/ViewModels/GenerationViewModel.swift
+++ b/iOS/Pixie/Pixie/ViewModels/GenerationViewModel.swift
@@ -268,6 +268,7 @@ class GenerationViewModel: ObservableObject {
         generationStartTime = Date()
         
         let metadata = ChatMessage.MessageMetadata(
+            model: options.model,
             size: options.size,
             quality: options.quality,
             credits: nil,
@@ -319,6 +320,7 @@ class GenerationViewModel: ObservableObject {
         error = nil
         
         let metadata = ChatMessage.MessageMetadata(
+            model: options.model,
             size: options.size.value,
             quality: options.quality.value,
             credits: nil,

--- a/iOS/Pixie/Pixie/Views/ChatInputBar.swift
+++ b/iOS/Pixie/Pixie/Views/ChatInputBar.swift
@@ -35,6 +35,8 @@ class ChatInputBar: UIView {
     private var heightConstraint: NSLayoutConstraint!
     private var creditsLabelTopToAdvancedConstraint: NSLayoutConstraint!
     private var creditsLabelTopToButtonConstraint: NSLayoutConstraint!
+    private var creditsLabelTopToModelConstraint: NSLayoutConstraint!
+    private var openAIConstraints: [NSLayoutConstraint] = []
     private var promptTextViewTopToHandleConstraint: NSLayoutConstraint!
     private var promptTextViewTopToImageConstraint: NSLayoutConstraint!
     var onSend: ((String) -> Void)?
@@ -360,10 +362,24 @@ class ChatInputBar: UIView {
             generateButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -contentPadding)
         ])
         updateCredits()
+
+        openAIConstraints = [
+            modelLabel.topAnchor.constraint(equalTo: promptTextView.bottomAnchor, constant: 16),
+            modelSelector.topAnchor.constraint(equalTo: modelLabel.bottomAnchor, constant: 8),
+            sizeLabel.topAnchor.constraint(equalTo: modelSelector.bottomAnchor, constant: 16),
+            sizeSelector.topAnchor.constraint(equalTo: sizeLabel.bottomAnchor, constant: 8),
+            qualityLabel.topAnchor.constraint(equalTo: sizeSelector.bottomAnchor, constant: 16),
+            qualitySelector.topAnchor.constraint(equalTo: qualityLabel.bottomAnchor, constant: 8),
+            advancedOptionsButton.topAnchor.constraint(equalTo: qualitySelector.bottomAnchor, constant: 16)
+        ]
+
         creditsLabelTopToAdvancedConstraint = creditsLabel.topAnchor.constraint(equalTo: advancedOptionsContainer.bottomAnchor, constant: 12)
         creditsLabelTopToButtonConstraint = creditsLabel.topAnchor.constraint(equalTo: advancedOptionsButton.bottomAnchor, constant: 12)
+        creditsLabelTopToModelConstraint = creditsLabel.topAnchor.constraint(equalTo: modelSelector.bottomAnchor, constant: 16)
+
         creditsLabelTopToButtonConstraint.isActive = true
         creditsLabelTopToAdvancedConstraint.isActive = false
+        creditsLabelTopToModelConstraint.isActive = false
         promptTextViewTopToHandleConstraint.isActive = true
         promptTextViewTopToImageConstraint.isActive = false
     }
@@ -513,6 +529,16 @@ class ChatInputBar: UIView {
     private func updateUIForModel() {
         let isOpenAI = selectedModel == .openai
 
+        if isOpenAI {
+            creditsLabelTopToModelConstraint.isActive = false
+            creditsLabelTopToButtonConstraint.isActive = !showAdvancedOptions
+            creditsLabelTopToAdvancedConstraint.isActive = showAdvancedOptions
+        } else {
+            creditsLabelTopToButtonConstraint.isActive = false
+            creditsLabelTopToAdvancedConstraint.isActive = false
+            creditsLabelTopToModelConstraint.isActive = true
+        }
+
         UIView.animate(withDuration: 0.3) { [weak self] in
             guard let self = self else { return }
             self.expandedView.viewWithTag(902)?.isHidden = !isOpenAI
@@ -525,6 +551,7 @@ class ChatInputBar: UIView {
             self.expandedView.viewWithTag(905)?.alpha = isOpenAI ? 1.0 : 0.0
             self.expandedView.viewWithTag(906)?.isHidden = !isOpenAI
             self.expandedView.viewWithTag(906)?.alpha = isOpenAI ? 1.0 : 0.0
+            self.expandedView.layoutIfNeeded()
         }
     }
 
@@ -706,6 +733,7 @@ class ChatInputBar: UIView {
         let fidelity = [FidelityLevel.low, .high][fidelitySelector.selectedSegmentIndex]
         return EditOptions(
             prompt: promptTextView.text ?? "",
+            model: selectedModel.value,
             variations: 1,
             size: size,
             quality: quality,

--- a/iOS/Pixie/Pixie/Views/ChatInputBar.swift
+++ b/iOS/Pixie/Pixie/Views/ChatInputBar.swift
@@ -14,6 +14,7 @@ class ChatInputBar: UIView {
     }
     private let indicatorStackView = UIStackView()
     private let promptTextView = UITextView()
+    private let modelSelector = UISegmentedControl(items: ["Gemini", "OpenAI GPT"])
     private let sizeSelector = UISegmentedControl(items: ["Auto", "Square", "Landscape", "Portrait"])
     private let qualitySelector = UISegmentedControl(items: ["Auto", "Low", "Medium", "High"])
     private let advancedOptionsButton = UIButton(type: .system)
@@ -41,6 +42,12 @@ class ChatInputBar: UIView {
     var currentPrompt: String? {
         let basePrompt = promptTextView.text
         return selectedSuggestionsManager?.composePrompt(basePrompt: basePrompt ?? "") ?? basePrompt
+    }
+    var selectedModel: ImageModel {
+        let models: [ImageModel] = [.gemini, .openai]
+        let index = modelSelector.selectedSegmentIndex
+        guard index >= 0 && index < models.count else { return .gemini }
+        return models[index]
     }
     var selectedSize: ImageSize {
         let sizes: [ImageSize] = [.auto, .square, .landscape, .portrait]
@@ -232,17 +239,29 @@ class ChatInputBar: UIView {
         promptTextView.isScrollEnabled = false
         promptTextView.delegate = self
         contentView.addSubview(promptTextView)
+        let modelLabel = createLabel("AI Model")
+        modelLabel.tag = 900
+        contentView.addSubview(modelLabel)
+        modelSelector.translatesAutoresizingMaskIntoConstraints = false
+        modelSelector.addTarget(self, action: #selector(modelChanged), for: .valueChanged)
+        modelSelector.tag = 901
+        contentView.addSubview(modelSelector)
         let sizeLabel = createLabel("Size")
+        sizeLabel.tag = 902
         contentView.addSubview(sizeLabel)
         sizeSelector.translatesAutoresizingMaskIntoConstraints = false
         sizeSelector.addTarget(self, action: #selector(updateCredits), for: .valueChanged)
+        sizeSelector.tag = 903
         contentView.addSubview(sizeSelector)
         let qualityLabel = createLabel("Quality")
+        qualityLabel.tag = 904
         contentView.addSubview(qualityLabel)
         qualitySelector.translatesAutoresizingMaskIntoConstraints = false
         qualitySelector.addTarget(self, action: #selector(updateCredits), for: .valueChanged)
+        qualitySelector.tag = 905
         contentView.addSubview(qualitySelector)
         advancedOptionsButton.translatesAutoresizingMaskIntoConstraints = false
+        advancedOptionsButton.tag = 906
         advancedOptionsButton.backgroundColor = .secondarySystemFill
         advancedOptionsButton.layer.cornerRadius = 12
         advancedOptionsButton.contentHorizontalAlignment = .left
@@ -311,7 +330,12 @@ class ChatInputBar: UIView {
             promptTextView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: contentPadding),
             promptTextView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -contentPadding),
             promptTextView.heightAnchor.constraint(greaterThanOrEqualToConstant: 100),
-            sizeLabel.topAnchor.constraint(equalTo: promptTextView.bottomAnchor, constant: 16),
+            modelLabel.topAnchor.constraint(equalTo: promptTextView.bottomAnchor, constant: 16),
+            modelLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: contentPadding),
+            modelSelector.topAnchor.constraint(equalTo: modelLabel.bottomAnchor, constant: 8),
+            modelSelector.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: contentPadding),
+            modelSelector.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -contentPadding),
+            sizeLabel.topAnchor.constraint(equalTo: modelSelector.bottomAnchor, constant: 16),
             sizeLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: contentPadding),
             sizeSelector.topAnchor.constraint(equalTo: sizeLabel.bottomAnchor, constant: 8),
             sizeSelector.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: contentPadding),
@@ -480,7 +504,36 @@ class ChatInputBar: UIView {
             clear()
         }
     }
+    @objc private func modelChanged() {
+        HapticManager.shared.impact(.click)
+        updateUIForModel()
+        updateCredits()
+    }
+
+    private func updateUIForModel() {
+        let isOpenAI = selectedModel == .openai
+
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            guard let self = self else { return }
+            self.expandedView.viewWithTag(902)?.isHidden = !isOpenAI
+            self.expandedView.viewWithTag(902)?.alpha = isOpenAI ? 1.0 : 0.0
+            self.expandedView.viewWithTag(903)?.isHidden = !isOpenAI
+            self.expandedView.viewWithTag(903)?.alpha = isOpenAI ? 1.0 : 0.0
+            self.expandedView.viewWithTag(904)?.isHidden = !isOpenAI
+            self.expandedView.viewWithTag(904)?.alpha = isOpenAI ? 1.0 : 0.0
+            self.expandedView.viewWithTag(905)?.isHidden = !isOpenAI
+            self.expandedView.viewWithTag(905)?.alpha = isOpenAI ? 1.0 : 0.0
+            self.expandedView.viewWithTag(906)?.isHidden = !isOpenAI
+            self.expandedView.viewWithTag(906)?.alpha = isOpenAI ? 1.0 : 0.0
+        }
+    }
+
     @objc private func updateCredits() {
+        if let fixedCost = selectedModel.fixedCost {
+            creditsLabel.text = "\(fixedCost) credits"
+            return
+        }
+
         let quality = selectedQuality.value
         let size = selectedSize.value
         let creditsRange: ClosedRange<Int>
@@ -665,7 +718,15 @@ class ChatInputBar: UIView {
     
     func applyDefaults() {
         let config = ConfigurationManager.shared
-        
+
+        switch config.defaultModel {
+        case "gemini-2.5-flash": modelSelector.selectedSegmentIndex = 0
+        case "gpt-image-1": modelSelector.selectedSegmentIndex = 1
+        default: modelSelector.selectedSegmentIndex = 0
+        }
+
+        updateUIForModel()
+
         switch config.defaultSize {
         case "auto": sizeSelector.selectedSegmentIndex = 0
         case "1024x1024": sizeSelector.selectedSegmentIndex = 1

--- a/iOS/Pixie/Pixie/Views/ChatTableView.swift
+++ b/iOS/Pixie/Pixie/Views/ChatTableView.swift
@@ -257,33 +257,37 @@ class UserMessageCell: UITableViewCell {
         editImageBottomConstraint.isActive = false
         
         if let metadata = message.metadata {
-            let titleLabel = createMetadataLabel(text: metadata.isEditMode ? "✏️ Edit Request" : "🎨 Generation Request", isBold: true)
-            metadataStackView.addArrangedSubview(titleLabel)
-            
-            let divider = UIView()
-            divider.backgroundColor = UIColor.white.withAlphaComponent(0.3)
-            divider.heightAnchor.constraint(equalToConstant: 0.5).isActive = true
-            metadataStackView.addArrangedSubview(divider)
-            
-            addMetadataRow("Quality", value: metadata.quality?.uppercased() ?? "")
-            
-            if let sizeDisplay = metadata.sizeDisplay {
-                addMetadataRow("Size", value: sizeDisplay)
-            }
-            
-            if let background = metadata.background {
-                addMetadataRow("Background", value: background)
-            }
-            
-            if let format = metadata.format {
-                addMetadataRow("Format", value: format)
-                if let compression = metadata.compression {
-                    addMetadataRow("Compress", value: "\(compression)%")
+            let isGemini = metadata.model?.starts(with: "gemini") ?? false
+
+            if !isGemini {
+                let titleLabel = createMetadataLabel(text: metadata.isEditMode ? "✏️ Edit Request" : "🎨 Generation Request", isBold: true)
+                metadataStackView.addArrangedSubview(titleLabel)
+
+                let divider = UIView()
+                divider.backgroundColor = UIColor.white.withAlphaComponent(0.3)
+                divider.heightAnchor.constraint(equalToConstant: 0.5).isActive = true
+                metadataStackView.addArrangedSubview(divider)
+
+                addMetadataRow("Quality", value: metadata.quality?.uppercased() ?? "")
+
+                if let sizeDisplay = metadata.sizeDisplay {
+                    addMetadataRow("Size", value: sizeDisplay)
                 }
-            }
-            
-            if let moderation = metadata.moderation {
-                addMetadataRow("Moderation", value: moderation)
+
+                if let background = metadata.background {
+                    addMetadataRow("Background", value: background)
+                }
+
+                if let format = metadata.format {
+                    addMetadataRow("Format", value: format)
+                    if let compression = metadata.compression {
+                        addMetadataRow("Compress", value: "\(compression)%")
+                    }
+                }
+
+                if let moderation = metadata.moderation {
+                    addMetadataRow("Moderation", value: moderation)
+                }
             }
         }
         

--- a/iOS/Pixie/Pixie/Views/GenerationToolbar.swift
+++ b/iOS/Pixie/Pixie/Views/GenerationToolbar.swift
@@ -13,7 +13,8 @@ class GenerationToolbar: UIView {
     
     var onExpandedChange: ((Bool) -> Void)?
     var onGenerate: ((GenerationOptions) -> Void)?
-    
+
+    private var selectedModel = ImageModel.gemini
     private var selectedSize = ImageSize.auto
     private var selectedQuality = ImageQuality.low
     private var selectedBackground: BackgroundStyle?
@@ -156,13 +157,19 @@ class GenerationToolbar: UIView {
         ])
         
         let promptSection = createPromptSection()
+        let modelSection = createModelSection()
         let sizeSection = createSizeSection()
         let qualitySection = createQualitySection()
         let advancedSection = createAdvancedSection()
         let generateSection = createGenerateSection()
-        
+
+        sizeSection.tag = 9000
+        qualitySection.tag = 9001
+        advancedSection.tag = 9002
+
         expandedStackView.addArrangedSubview(headerView)
         expandedStackView.addArrangedSubview(promptSection)
+        expandedStackView.addArrangedSubview(modelSection)
         expandedStackView.addArrangedSubview(sizeSection)
         expandedStackView.addArrangedSubview(qualitySection)
         expandedStackView.addArrangedSubview(advancedSection)
@@ -215,7 +222,148 @@ class GenerationToolbar: UIView {
         
         return section
     }
-    
+
+    private func createModelSection() -> UIView {
+        let section = UIView()
+
+        let headerStack = UIStackView()
+        headerStack.translatesAutoresizingMaskIntoConstraints = false
+        headerStack.axis = .horizontal
+        headerStack.spacing = 6
+        headerStack.alignment = .center
+        section.addSubview(headerStack)
+
+        let iconView = UIImageView()
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.image = UIImage(systemName: "cpu")
+        iconView.tintColor = .systemBlue
+        iconView.contentMode = .scaleAspectFit
+
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "AI Model"
+        label.font = .systemFont(ofSize: 16, weight: .medium)
+
+        headerStack.addArrangedSubview(iconView)
+        headerStack.addArrangedSubview(label)
+
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.showsHorizontalScrollIndicator = false
+        section.addSubview(scrollView)
+
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        scrollView.addSubview(stackView)
+
+        for (index, model) in ImageModel.allCases.enumerated() {
+            let button = createModelButton(model: model)
+            button.tag = 8000 + index
+            button.addAction(UIAction { [weak self] _ in
+                HapticManager.shared.impact(.click)
+                stackView.arrangedSubviews.forEach { view in
+                    if let btn = view as? UIButton {
+                        btn.isSelected = btn == button
+                    }
+                }
+                self?.selectedModel = model
+                self?.updateUIForModel()
+                self?.updateGenerateButton()
+            }, for: .touchUpInside)
+
+            if model == selectedModel {
+                button.isSelected = true
+            }
+
+            stackView.addArrangedSubview(button)
+        }
+
+        NSLayoutConstraint.activate([
+            headerStack.topAnchor.constraint(equalTo: section.topAnchor),
+            headerStack.leadingAnchor.constraint(equalTo: section.leadingAnchor),
+
+            iconView.widthAnchor.constraint(equalToConstant: 18),
+            iconView.heightAnchor.constraint(equalToConstant: 18),
+
+            scrollView.topAnchor.constraint(equalTo: headerStack.bottomAnchor, constant: 12),
+            scrollView.leadingAnchor.constraint(equalTo: section.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: section.trailingAnchor),
+            scrollView.heightAnchor.constraint(equalToConstant: 80),
+            scrollView.bottomAnchor.constraint(equalTo: section.bottomAnchor),
+
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            stackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor)
+        ])
+
+        return section
+    }
+
+    private func createModelButton(model: ImageModel) -> UIButton {
+        let button = UIButton(type: .custom)
+        button.translatesAutoresizingMaskIntoConstraints = false
+
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = 2
+        stackView.alignment = .center
+        stackView.isUserInteractionEnabled = false
+
+        let titleLabel = UILabel()
+        titleLabel.text = model.displayName
+        titleLabel.font = .systemFont(ofSize: 14, weight: .medium)
+        titleLabel.textAlignment = .center
+
+        let descriptionLabel = UILabel()
+        descriptionLabel.text = model.description
+        descriptionLabel.font = .systemFont(ofSize: 11)
+        descriptionLabel.textAlignment = .center
+        descriptionLabel.alpha = 0.7
+        descriptionLabel.numberOfLines = 2
+
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(descriptionLabel)
+
+        button.addSubview(stackView)
+
+        button.layer.cornerRadius = 12
+        button.layer.borderWidth = 2
+        button.layer.borderColor = UIColor.clear.cgColor
+        button.backgroundColor = .secondarySystemFill
+
+        button.configurationUpdateHandler = { button in
+            UIView.animate(withDuration: 0.2) {
+                if button.isSelected {
+                    button.layer.borderColor = UIColor.systemBlue.cgColor
+                    button.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.1)
+                    titleLabel.textColor = .systemBlue
+                    descriptionLabel.textColor = .systemBlue
+                } else {
+                    button.layer.borderColor = UIColor.clear.cgColor
+                    button.backgroundColor = .secondarySystemFill
+                    titleLabel.textColor = .label
+                    descriptionLabel.textColor = .secondaryLabel
+                }
+            }
+        }
+
+        NSLayoutConstraint.activate([
+            button.widthAnchor.constraint(equalToConstant: 140),
+            button.heightAnchor.constraint(equalToConstant: 80),
+            stackView.centerXAnchor.constraint(equalTo: button.centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: button.centerYAnchor),
+            stackView.leadingAnchor.constraint(equalTo: button.leadingAnchor, constant: 8),
+            stackView.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -8)
+        ])
+
+        return button
+    }
+
     private func createSizeSection() -> UIView {
         let section = UIView()
         
@@ -844,6 +992,10 @@ class GenerationToolbar: UIView {
     }
     
     private func estimateCredits() -> ClosedRange<Int> {
+        if let fixedCost = selectedModel.fixedCost {
+            return fixedCost...fixedCost
+        }
+
         let baseCredits: ClosedRange<Int>
         switch selectedQuality {
         case .low:
@@ -867,7 +1019,7 @@ class GenerationToolbar: UIView {
         case .auto:
             baseCredits = 50...75
         }
-        
+
         return baseCredits
     }
     
@@ -961,26 +1113,34 @@ class GenerationToolbar: UIView {
     
     @objc private func generateTapped() {
         HapticManager.shared.impact(.click)
-        
-        let prompt = isExpanded ? 
+
+        let prompt = isExpanded ?
             (expandedStackView.arrangedSubviews.first?.subviews.compactMap { $0 as? UITextView }.first?.text ?? "") :
             (promptTextField.text ?? "")
-        
+
         guard !prompt.isEmpty else { return }
-        
+
         var options = GenerationOptions.default
         options.prompt = prompt
+        options.model = selectedModel.value
         options.quantity = 1
-        options.size = selectedSize.value
-        options.sizeDisplay = selectedSize.displayName
-        options.quality = selectedQuality.value
-        
+
+        if selectedModel == .openai {
+            options.size = selectedSize.value
+            options.sizeDisplay = selectedSize.displayName
+            options.quality = selectedQuality.value
+        } else {
+            options.size = "auto"
+            options.sizeDisplay = "Auto"
+            options.quality = "low"
+        }
+
         onGenerate?(options)
     }
     
     @objc private func optionButtonTapped(_ sender: UIButton) {
         HapticManager.shared.impact(.click)
-        
+
         if let stackView = sender.superview as? UIStackView {
             stackView.arrangedSubviews.forEach { view in
                 if let button = view as? UIButton {
@@ -988,6 +1148,86 @@ class GenerationToolbar: UIView {
                 }
             }
         }
+    }
+
+    private func updateUIForModel() {
+        let isOpenAI = selectedModel == .openai
+
+        expandedStackView.arrangedSubviews.forEach { view in
+            switch view.tag {
+            case 9000, 9001, 9002:
+                UIView.animate(withDuration: 0.3) {
+                    view.isHidden = !isOpenAI
+                    view.alpha = isOpenAI ? 1.0 : 0.0
+                }
+            default:
+                break
+            }
+        }
+    }
+
+    private func updateGenerateButton() {
+        if let generateSection = expandedStackView.arrangedSubviews.last,
+           let button = generateSection.subviews.first as? UIButton {
+            button.setNeedsUpdateConfiguration()
+        }
+    }
+
+    func applyDefaults() {
+        let config = ConfigurationManager.shared
+
+        if let model = ImageModel(rawValue: config.defaultModel) {
+            selectedModel = model
+        } else {
+            selectedModel = .gemini
+        }
+
+        switch config.defaultSize {
+        case "auto": selectedSize = .auto
+        case "1024x1024": selectedSize = .square
+        case "1536x1024": selectedSize = .landscape
+        case "1024x1536": selectedSize = .portrait
+        default: selectedSize = .auto
+        }
+
+        switch config.defaultQuality {
+        case "low": selectedQuality = .low
+        case "medium": selectedQuality = .medium
+        case "high": selectedQuality = .high
+        case "auto": selectedQuality = .auto
+        default: selectedQuality = .low
+        }
+
+        if !config.defaultOutputFormat.isEmpty {
+            switch config.defaultOutputFormat {
+            case "png": selectedFormat = .png
+            case "jpeg": selectedFormat = .jpeg
+            case "webp": selectedFormat = .webp
+            default: selectedFormat = nil
+            }
+        }
+
+        compressionLevel = config.defaultCompression
+
+        if !config.defaultBackground.isEmpty {
+            switch config.defaultBackground {
+            case "auto": selectedBackground = .auto
+            case "transparent": selectedBackground = .transparent
+            case "white": selectedBackground = .white
+            case "black": selectedBackground = .black
+            default: selectedBackground = nil
+            }
+        }
+
+        if !config.defaultModeration.isEmpty {
+            switch config.defaultModeration {
+            case "auto": selectedModeration = .auto
+            case "low": selectedModeration = .low
+            default: selectedModeration = nil
+            }
+        }
+
+        updateUIForModel()
     }
 }
 

--- a/src/credits.rs
+++ b/src/credits.rs
@@ -398,10 +398,15 @@ pub async fn get_user_transactions(
 }
 
 pub fn estimate_image_cost(
+    model: &str,
     quality: &str,
     size: &str,
     is_edit: bool,
 ) -> u32 {
+    if model.starts_with("gemini") {
+        return 15;
+    }
+
     // Based on gpt-image-1 documentation:
     // Low: 272-408 tokens, Medium: 1056-1584 tokens, High: 4160-6240 tokens
     let base_estimate = match (quality, size) {
@@ -476,24 +481,29 @@ mod tests {
     
     #[test]
     fn test_estimate_image_cost() {
-        // Test generation costs
-        assert_eq!(estimate_image_cost("low", "1024x1024", false), 4);
-        assert_eq!(estimate_image_cost("low", "1536x1024", false), 6);
-        assert_eq!(estimate_image_cost("medium", "1024x1024", false), 16);
-        assert_eq!(estimate_image_cost("medium", "1536x1024", false), 24);
-        assert_eq!(estimate_image_cost("high", "1024x1024", false), 62);
-        assert_eq!(estimate_image_cost("high", "1536x1024", false), 94);
-        assert_eq!(estimate_image_cost("high", "512x512", false), 78); // other high quality sizes
-        assert_eq!(estimate_image_cost("auto", "1024x1024", false), 50);
-        assert_eq!(estimate_image_cost("auto", "1536x1024", false), 75);
-        
-        // Test edit operations
-        assert_eq!(estimate_image_cost("low", "1024x1024", true), 7); // 4 + 3
-        assert_eq!(estimate_image_cost("medium", "1024x1024", true), 19); // 16 + 3
-        assert_eq!(estimate_image_cost("high", "1024x1024", true), 82); // 62 + 20
-        assert_eq!(estimate_image_cost("high", "1536x1024", true), 114); // 94 + 20
-        assert_eq!(estimate_image_cost("auto", "1024x1024", true), 68); // 50 + 18
-        assert_eq!(estimate_image_cost("auto", "1536x1024", true), 93); // 75 + 18
+        // Test Gemini costs (always 15)
+        assert_eq!(estimate_image_cost("gemini-2.5-flash", "low", "1024x1024", false), 15);
+        assert_eq!(estimate_image_cost("gemini-2.5-flash", "low", "1536x1024", true), 15);
+        assert_eq!(estimate_image_cost("gemini-2.5-flash", "high", "auto", false), 15);
+
+        // Test OpenAI generation costs
+        assert_eq!(estimate_image_cost("gpt-image-1", "low", "1024x1024", false), 4);
+        assert_eq!(estimate_image_cost("gpt-image-1", "low", "1536x1024", false), 6);
+        assert_eq!(estimate_image_cost("gpt-image-1", "medium", "1024x1024", false), 16);
+        assert_eq!(estimate_image_cost("gpt-image-1", "medium", "1536x1024", false), 24);
+        assert_eq!(estimate_image_cost("gpt-image-1", "high", "1024x1024", false), 62);
+        assert_eq!(estimate_image_cost("gpt-image-1", "high", "1536x1024", false), 94);
+        assert_eq!(estimate_image_cost("gpt-image-1", "high", "512x512", false), 78);
+        assert_eq!(estimate_image_cost("gpt-image-1", "auto", "1024x1024", false), 50);
+        assert_eq!(estimate_image_cost("gpt-image-1", "auto", "1536x1024", false), 75);
+
+        // Test OpenAI edit operations
+        assert_eq!(estimate_image_cost("gpt-image-1", "low", "1024x1024", true), 7); // 4 + 3
+        assert_eq!(estimate_image_cost("gpt-image-1", "medium", "1024x1024", true), 19); // 16 + 3
+        assert_eq!(estimate_image_cost("gpt-image-1", "high", "1024x1024", true), 82); // 62 + 20
+        assert_eq!(estimate_image_cost("gpt-image-1", "high", "1536x1024", true), 114); // 94 + 20
+        assert_eq!(estimate_image_cost("gpt-image-1", "auto", "1024x1024", true), 68); // 50 + 18
+        assert_eq!(estimate_image_cost("gpt-image-1", "auto", "1536x1024", true), 93); // 75 + 18
     }
     
     #[test]

--- a/src/handlers/credits.rs
+++ b/src/handlers/credits.rs
@@ -179,12 +179,8 @@ pub async fn estimate_cost(mut req: Request, _ctx: RouteContext<()>) -> Result<R
     let n = estimate_req.n.unwrap_or(1);
     let is_edit = estimate_req.is_edit.unwrap_or(false);
     let model = estimate_req.model.as_deref().unwrap_or("gemini-2.5-flash");
-    
-    let credits_per_image = if model.starts_with("gemini") {
-        15
-    } else {
-        estimate_image_cost(&estimate_req.quality, &estimate_req.size, is_edit)
-    };
+
+    let credits_per_image = estimate_image_cost(model, &estimate_req.quality, &estimate_req.size, is_edit);
     
     let total_credits = credits_per_image * n as u32;
     

--- a/src/handlers/images.rs
+++ b/src/handlers/images.rs
@@ -54,7 +54,8 @@ pub async fn handle_generation(mut req: Request, ctx: RouteContext<()>) -> Resul
     
     // Estimate credit cost and check balance
     let estimated_credits = estimate_image_cost(
-        &generation_req.quality, 
+        &generation_req.model,
+        &generation_req.quality,
         &generation_req.size,
         false
     ) * generation_req.n as u32;
@@ -341,7 +342,8 @@ pub async fn handle_edit(mut req: Request, ctx: RouteContext<()>) -> Result<Resp
     
     // Estimate credit cost for edit operation and check balance
     let estimated_credits = estimate_image_cost(
-        &edit_req.quality, 
+        &edit_req.model,
+        &edit_req.quality,
         &edit_req.size,
         true // is_edit
     ) * edit_req.n as u32;

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -286,9 +286,9 @@ impl ImageProvider for OpenAIProvider {
         let quality = request.quality.as_deref().unwrap_or("auto");
         let size = request.size.as_deref().unwrap_or("1024x1024");
         let n = request.n.unwrap_or(1) as u32;
-        
-        let credits_per_image = estimate_image_cost(quality, size, false);
-        
+
+        let credits_per_image = estimate_image_cost(&request.model, quality, size, false);
+
         CostEstimate {
             credits: credits_per_image * n,
             provider: "openai".to_string(),
@@ -299,9 +299,9 @@ impl ImageProvider for OpenAIProvider {
         let quality = request.quality.as_deref().unwrap_or("auto");
         let size = request.size.as_deref().unwrap_or("1024x1024");
         let n = request.n.unwrap_or(1) as u32;
-        
-        let credits_per_image = estimate_image_cost(quality, size, true);
-        
+
+        let credits_per_image = estimate_image_cost(&request.model, quality, size, true);
+
         CostEstimate {
             credits: credits_per_image * n,
             provider: "openai".to_string(),


### PR DESCRIPTION
## Summary
- Adds Google Gemini (gemini-2.5-flash) as a model option alongside OpenAI
- Implements conditional UI that shows/hides options based on selected model
- Achieves feature parity with Android implementation

## Changes

### Core Model Support
- **ImageModel enum**: Gemini and OpenAI with display names, descriptions, and cost info
- **ConfigurationManager**: Added `defaultModel` property (defaults to Gemini)
- **GenerationOptions**: Added model field to support both models
- **EditOptions**: Added model field for edit mode support

### UI Implementation
- **Settings**: Model selector as first option in Defaults section
- **ChatInputBar**: 
  - Model selector with conditional visibility for size/quality/advanced options
  - Smooth fade animations when switching models
  - Smart constraint management to eliminate UI gaps
- **GenerationToolbar**: Same conditional UI pattern with rich button displays
- **Chat Bubbles**: Hide configuration details for Gemini (show only for OpenAI)

### Model Behavior
**Gemini (Simple)**
- Fixed 15 credits
- Auto size, low quality (locked)
- No advanced options (background, format, compression, moderation)
- Clean chat history with no config details

**OpenAI (Advanced)**  
- Variable cost (5-94 credits depending on settings)
- Full control over all generation parameters
- All existing features preserved

### State Management
- Model selection persists across app launches
- Configuration changes trigger UI updates via NotificationCenter
- Smooth transitions with proper constraint switching
- Default values applied correctly on initialization

## Testing
- ✅ Build succeeds with no compiler errors
- ✅ No code comments added
- ✅ Model switching works smoothly with animations
- ✅ UI properly collapses for Gemini (no gaps)
- ✅ Chat bubbles show correct metadata per model
- ✅ Both generate and edit modes respect model selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)